### PR TITLE
Fix unsafe `replaceFirst` call

### DIFF
--- a/src/main/java/com/jflyfox/modules/filemanager/FileManager.java
+++ b/src/main/java/com/jflyfox/modules/filemanager/FileManager.java
@@ -946,7 +946,7 @@ public class FileManager {
         }
 
         if (path.startsWith(contextPath)) {
-            path = path.replaceFirst(contextPath, "");
+            path = path.substring(contextPath.length());
         }
         return path;
     }


### PR DESCRIPTION
Fixes https://github.com/jflyfox/jfinal_cms/issues/23
Uses `substring` to replace the first occurrence without regex.