### PR TITLE
Issue ID: CVE-2022-33113

### DIFF
--- a/src/main/java/com/jflyfox/modules/front/controller/ArticleController.java
+++ b/src/main/java/com/jflyfox/modules/front/controller/ArticleController.java
@@ -16,6 +16,7 @@ import com.jflyfox.modules.admin.tags.TbTags;
 import com.jflyfox.modules.front.interceptor.FrontInterceptor;
 import com.jflyfox.modules.front.service.FrontCacheService;
 import com.jflyfox.util.StrUtils;
+import com.jflyfox.util.extend.HtmlUtils;
 
 /**
  * 文章管理
@@ -61,6 +62,12 @@ public class ArticleController extends BaseProjectController {
 				new FrontCacheService().addArticleCount(article);
 			}
 
+			// Fix for CVE-2022-33113...
+			// HtmlUtils.escapeHtml() is applied for content and title...
+			// This utility function helps to escape the characters in a String using HTML entities
+			if (article.getTitle().equals(HtmlUtils.unescapeHtml(article.getTitle()))) {
+				article.setTitle(HtmlUtils.escapeHtml(article.getTitle()));
+			}
 			setAttr("item", article);
 
 			// seo：title优化
@@ -70,6 +77,14 @@ public class ArticleController extends BaseProjectController {
 			// List<TbTags> taglist = new FrontCacheService().getTagsByArticle(articleId);
 			List<TbTags> taglist = TbTags.dao.find("select * from tb_tags " //
 					+ "where article_id = ? order by  create_time desc ", articleId);
+			// Fix for CVE-2022-33113...
+			// HtmlUtils.escapeHtml() is applied for all keywords retrieved...
+			// This utility function helps to escape the characters in a String using HTML entities
+			for(TbTags tag: taglist) {
+				if (tag.getTagname().equals(HtmlUtils.unescapeHtml(tag.getTagname()))) {
+					tag.setTagname(HtmlUtils.escapeHtml(tag.getTagname()));
+				}
+			}
 			setAttr("taglist", taglist);
 
 			// 评论

--- a/src/main/java/com/jflyfox/modules/front/controller/PersonController.java
+++ b/src/main/java/com/jflyfox/modules/front/controller/PersonController.java
@@ -56,7 +56,7 @@ public class PersonController extends BaseProjectController {
 						+ " where " + getPublicWhere() //
 						+ " and t.create_id = ? and tf.site_id = ? " //
 						+ " order by t.sort,t.create_time desc", user.getUserid(), getSessionSite().getSiteId());
-		setAttr("page", articles);
+		setAttr("page", escapeHtmlInArticles(articles));
 
 		// 显示50个标签
 		if (articles.getTotalRow() > 0) {
@@ -95,7 +95,7 @@ public class PersonController extends BaseProjectController {
 						+ " where " + getPublicWhere() //
 						+ " and t.create_id = ? and tf.site_id = ? " //
 						+ " order by t.sort,t.create_time desc", user.getUserid(), getSessionSite().getSiteId());
-		setAttr("page", articles);
+		setAttr("page", escapeHtmlInArticles(articles));
 
 		// 显示50个标签
 		if (articles.getTotalRow() > 0) {
@@ -135,7 +135,7 @@ public class PersonController extends BaseProjectController {
 						+ " left join tb_articlelike al on al.article_id = t.id" + " where " + getPublicWhere() //
 						+ " and al.create_id = ? and tf.site_id = ? " //
 						+ " order by t.sort,t.create_time desc", user.getUserid(), getSessionSite().getSiteId());
-		setAttr("page", articles);
+		setAttr("page", escapeHtmlInArticles(articles));
 
 		// 显示50个标签
 		if (articles.getTotalRow() > 0) {
@@ -258,6 +258,12 @@ public class PersonController extends BaseProjectController {
 		content = JFlyFoxUtils.delScriptTag(content);
 		title = HtmlUtils.delHTMLTag(title);
 		tags = HtmlUtils.delHTMLTag(tags);
+
+		// Fix for CVE-2022-33113...
+		// HtmlUtils.escapeHtml() is applied for title and tags variable...
+		// This utility function helps to escape the characters in a String using HTML entities
+		title = HtmlUtils.escapeHtml(title);
+		tags = HtmlUtils.escapeHtml(tags);
 
 		// 这里没有必要提示太精准~因为前台有验证~绕过的都不是好人哦
 		if (content == null || HtmlUtils.delHTMLTag(content).length() > 2000 //
@@ -457,7 +463,7 @@ public class PersonController extends BaseProjectController {
 						+ " where  " + getPublicWhere() //
 						+ " and t.create_id = ? and tf.site_id = ? " //
 						+ " order by t.sort,t.create_time desc", userid, getSessionSite().getSiteId());
-		setAttr("page", articles);
+		setAttr("page", escapeHtmlInArticles(articles));
 
 		// 显示50个标签
 		if (articles.getTotalRow() > 0) {
@@ -474,6 +480,21 @@ public class PersonController extends BaseProjectController {
 
 		renderAuto(path + "view_person.html");
 
+	}
+
+	protected Page<TbArticle> escapeHtmlInArticles(Page<TbArticle> articles) {
+		// Fix for CVE-2022-33113...
+		// HtmlUtils.escapeHtml() is applied for title of all article elements...
+		// This utility function helps to escape the characters in a String using HTML entities
+		if (articles.getTotalRow() > 0) {
+			for (TbArticle article : articles.getList()) {
+				//for now, we have applied escape HTML only for title field... to be extended for other fields if required in future
+				if (article.getTitle().equals(HtmlUtils.unescapeHtml(article.getTitle()))) {
+					article.setTitle(HtmlUtils.escapeHtml(article.getTitle()));
+				}
+			}
+		}
+		return articles;
 	}
 
 	protected Page<TbTags> tags() {

--- a/src/main/java/com/jflyfox/util/extend/HtmlUtils.java
+++ b/src/main/java/com/jflyfox/util/extend/HtmlUtils.java
@@ -20,6 +20,8 @@ package com.jflyfox.util.extend;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 /**
  * html处理
  * 
@@ -122,6 +124,28 @@ public class HtmlUtils {
 		content = content.replaceAll("'", "");
 		content = content.replaceAll("/", "");
 		return content;
+	}
+
+	/**
+	 * Escapes the characters in a String using HTML entities
+	 * For example: "bread" & "butter" becomes: &quot;bread&quot; &amp; &quot;butter&quot;.
+	 *
+	 * @param plainHtmlString (the String to escape, may be null)
+	 * @return a new escaped String, null if null string input
+	 */
+	public static String escapeHtml(String plainHtmlString) {
+		return StringEscapeUtils.escapeHtml(plainHtmlString);
+	}
+
+	/**
+	 * Unescapes a string containing entity escapes to a string containing the actual Unicode characters corresponding to the escapes.
+	 * For example, the string "&lt;Fran&ccedil;ais&gt;" will become "<Français>".
+	 *
+	 * @param escapedHtmlString (the String to unescape, may be null)
+	 * @return a new unescaped String, null if null string input
+	 */
+	public static String unescapeHtml(String escapedHtmlString) {
+		return StringEscapeUtils.unescapeHtml(escapedHtmlString);
 	}
 
 }


### PR DESCRIPTION
Description: Jfinal CMS v5.1.0 allows attackers to execute arbitrary web scripts or HTML via a crafted payload injected into the keyword text field under the publish blog module.

Fixed in any other branch? : Fix doesn't exist in any of the existing branches.

Rootcause:
This vulnerability affects an unknown part of the Jfinal CMS component Publish Blog Module. The manipulation of the argument "keyword" with an unknown input leads to a cross site scripting vulnerability. The CWE definition for the vulnerability is CWE-79. The software does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users. As an impact it is known to affect integrity. An attacker might be able to inject arbitrary html and script code into the web site. This would alter the appearance and would make it possible to initiate further attacks against site visitors.

Steps to reproduce:
- There is a stored XSS vulnerability in JFinal_cms 's publish blog module.
- An attacker can insert malicious XSS code into the "Keyword" field. When the user views the content of the article in the foreground, the malicious XSS code is triggered successfully.
- payload: " onmouseover="alert(document.cookie)

Additional Findings:
- As per the CVE-2022-33113, XSS vulnerability is seen in the "Keyword" field. But, the same vulnerability is applicable to "Topic" field as well.

Fix:
- The fix here is to ensure that the input strings from the portal is sanitized properly to get rid of the html strings/tags.
- Here, we are making use of Apache common-lang's StringEscapeUtils APIs - escapeHtml() and unescapeHtml().
- escapeHtml(): Escapes the characters in a String using HTML entities. For example: "bread" & "butter" becomes: &quot;bread&quot; &amp; &quot;butter&quot;.
- unescapeHtml(): Unescapes a string containing entity escapes to a string containing the actual Unicode characters corresponding to the escapes. For example, the string "&lt;Fran&ccedil;ais&gt;" will become "<Français>".
- The fix is added in "AlertController" and "PersonController" classes in "com.jflyfox.modules.front.controller" packages. Also, "HtmlUtils" class will now expose two utility methods - escapeHtml() and unescapeHtml(), which can be used if required else where.
- The changes are added here to make use of the escapeHtml() and unescapeHtml() in "HtmlUtils" class for strings specified in "Topic" and "Keyword" fields.

Unit Testing:
- Verified that the XSS vulnerability is no more applicable for "Topic" and "Keyword" fields.
- Verified the fix in Chrome, Mozilla and Firefox browsers.